### PR TITLE
Set tested up to version to 5.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 Tags: slideshare, powerpoint, keynote, ppt, presentation, slide shows, presentations
 Requires at least: 5.6
-Tested up to: 5.7
+Tested up to: 5.8
 Stable tag: 1.9.2
 
 Easily embed SlideShare presentations into your WordPress posts by using the SlideShare WordPress.com embed code.


### PR DESCRIPTION
WordPress 5.8 is released on July 20th. This PR sets the tested up to version to 5.8.